### PR TITLE
Handler switching and request handler result DSL

### DIFF
--- a/src/main/scala/com/github/krasserm/ases/EventSourcing.scala
+++ b/src/main/scala/com/github/krasserm/ases/EventSourcing.scala
@@ -29,25 +29,6 @@ import scala.collection.immutable.Seq
 
 object EventSourcing {
   /**
-    * Request handler. Input is the current state and the current request. Output is a
-    * sequence of events to be written to an event log and a function for creating a
-    * response. The response function is called with the current state after the output
-    * events have been successfully written and applied to the [[EventHandler]]. If the
-    * output sequence of events is empty the response function is called immediately with
-    * the current state.
-    *
-    * Requests that cause the request handler to output an non-empty event sequence are
-    * called ''commands'' whereas requests that cause the request handler to output an
-    * empty event sequence are called ''queries''.
-    *
-    * @tparam S State type.
-    * @tparam E Event type.
-    * @tparam REQ Request type.
-    * @tparam RES Response type.
-    */
-  type RequestHandler[S, E, REQ, RES] = (S, REQ) => (Seq[E], S => RES)
-
-  /**
     * Event handler. Input is the current state and an event that has been written to an
     * event log. Output is the updated state that is set to the current state by the
     * [[EventSourcing]] driver.
@@ -55,7 +36,48 @@ object EventSourcing {
     * @tparam S State type.
     * @tparam E Event type.
     */
-  type EventHandler[S, E] = (S, E) => S
+  type EventHandler[S, E] =
+    (S, E) => S
+
+  /**
+    * Request handler. Input is the current state and the current request. Output is either
+    * a result created with [[respond]] or with [[emit]].
+    *
+    *  - [[respond]] creates an immediate response which can be either the response to a ''query''
+    *  or the failure response to a ''command'' whose validation failed, for example.
+    *  - [[emit]] returns a sequence of events to be written to an event log and a response factory
+    *  to be called with the current state after all written events have been applied to it.
+    *
+    * @tparam S State type.
+    * @tparam E Event type.
+    * @tparam REQ Request type.
+    * @tparam RES Response type.
+    */
+  type RequestHandler[S, E, REQ, RES] =
+    (S, REQ) => RequestHandlerResult[S, E, RES]
+
+  sealed trait RequestHandlerResult[S, E, RES]
+
+  private case class Respond[S, E, RES](response: RES)
+    extends RequestHandlerResult[S, E, RES]
+
+  private case class Emit[S, E, RES](events: Seq[E], responseFactory: S => RES)
+    extends RequestHandlerResult[S, E, RES] {
+    require(events.nonEmpty, "event sequence must not be empty")
+  }
+
+  /**
+    * Creates a request handler result that contains an immediate response.
+    */
+  def respond[S, E, RES](response: RES): RequestHandlerResult[S, E, RES] =
+    Respond(response)
+
+  /**
+    * Create a request handler result that contains events to be written to an event log and a response
+    * factory to be called with the current state after all written events have been applied to it.
+    */
+  def emit[S, E, RES](events: Seq[E], responseFactory: S => RES): RequestHandlerResult[S, E, RES] =
+    Emit(events, responseFactory)
 
   /**
     * Used by [[EventSourcing]] to correlate emitted events with input events (preliminary solution).
@@ -68,8 +90,8 @@ object EventSourcing {
   }
 
   /**
-    * Creates a bidi-flow that implements the driver for event sourcing logic defined by [[RequestHandler]]
-    * and [[EventHandler]]. The created event sourcing stage should be joined with an event log (i.e. a flow)
+    * Creates a bidi-flow that implements the driver for event sourcing logic defined by `requestHandler`
+    * `eventHandler`. The created event sourcing stage should be joined with an event log (i.e. a flow)
     * for writing emitted events. Written events are delivered from the joined event log back to the stage:
     *
     *  - After materialization, the stage's state is recovered with replayed events delivered by the joined
@@ -98,16 +120,52 @@ object EventSourcing {
       initial: S,
       requestHandler: RequestHandler[S, E, REQ, RES],
       eventHandler: EventHandler[S, E]): BidiFlow[REQ, Identified[E], Delivery[Identified[E]], RES, NotUsed] =
-    BidiFlow.fromGraph(new EventSourcing(initial, requestHandler, eventHandler))
+    BidiFlow.fromGraph(new EventSourcing[S, E, REQ, RES](initial, _ => requestHandler, _ => eventHandler))
+
+  /**
+    * Creates a bidi-flow that implements the driver for event sourcing logic returned by `requestHandlerProvider`
+    * and `eventHandlerProvider`. `requestHandlerProvider` is evaluated with current state for each received request,
+    * `eventHandlerProvider` is evaluated with current state for each written event. This can be used by applications
+    * to switch request and event handling logic as a function of current state. The created event sourcing stage
+    * should be joined with an event log (i.e. a flow) for writing emitted events. Written events are delivered
+    * from the joined event log back to the stage:
+    *
+    *  - After materialization, the stage's state is recovered with replayed events delivered by the joined
+    *    event log.
+    *  - On recovery completion (see [[DeliveryProtocol]]) the stage is ready to accept requests if there is
+    *    downstream response and event demand.
+    *  - On receiving a command it calls the request handler and emits the returned events. The emitted events
+    *    are sent downstream to the joined event log.
+    *  - For each written event that is delivered from the event log back to the event sourcing stage, the
+    *    event handler is called with that event and the current state. The stage updates its current state
+    *    with the event handler result.
+    *  - After all emitted events (for a given command) have been applied, the response function, previously
+    *    created by the command handler, is called with the current state and the created response is emitted.
+    *  - After response emission, the stage is ready to accept the next request if there is downstream response
+    *    and event demand.
+    *
+    * @param initial Initial state.
+    * @param requestHandlerProvider The stage's request handler provider.
+    * @param eventHandlerProvider The stage's event handler provider.
+    * @tparam S State type.
+    * @tparam E Event type.
+    * @tparam REQ Request type.
+    * @tparam RES Response type.
+    */
+  def apply[S, E, REQ, RES](
+      initial: S,
+      requestHandlerProvider: S => RequestHandler[S, E, REQ, RES],
+      eventHandlerProvider: S => EventHandler[S, E]): BidiFlow[REQ, Identified[E], Delivery[Identified[E]], RES, NotUsed] =
+    BidiFlow.fromGraph(new EventSourcing(initial, requestHandlerProvider, eventHandlerProvider))
 }
 
 private class EventSourcing[S, E, REQ, RES](
     initial: S,
-    requestHandler: RequestHandler[S, E, REQ, RES],
-    eventHandler: EventHandler[S, E])
+    requestHandlerProvider: S => RequestHandler[S, E, REQ, RES],
+    eventHandlerProvider: S => EventHandler[S, E])
   extends GraphStage[BidiShape[REQ, Identified[E], Delivery[Identified[E]], RES]] {
 
-  private case class Roundtrip(eventIds: Set[String], response: S => RES) {
+  private case class Roundtrip(eventIds: Set[String], responseFactory: S => RES) {
     def delivered(eventId: String): Roundtrip = copy(eventIds - eventId)
   }
 
@@ -127,14 +185,14 @@ private class EventSourcing[S, E, REQ, RES](
 
       setHandler(ci, new InHandler {
         override def onPush(): Unit = {
-          val (events, reply) = requestHandler(state, grab(ci))
-          if (events.isEmpty) {
-            push(ro, reply(state))
-            tryPullCi()
-          } else {
-            val identified = events.map(Identified(_))
-            roundtrip = Some(Roundtrip(identified.map(_.id)(collection.breakOut), reply))
-            emitMultiple(eo, identified)
+          requestHandlerProvider(state)(state, grab(ci)) match {
+            case Respond(response) =>
+              push(ro, response)
+              tryPullCi()
+            case Emit(events, responseFactory) =>
+              val identified = events.map(Identified(_))
+              roundtrip = Some(Roundtrip(identified.map(_.id)(collection.breakOut), responseFactory))
+              emitMultiple(eo, identified)
           }
         }
 
@@ -149,10 +207,10 @@ private class EventSourcing[S, E, REQ, RES](
               recovered = true
               tryPullCi()
             case Delivered(identified) =>
-              state = eventHandler(state, identified.event)
+              state = eventHandlerProvider(state)(state, identified.event)
               roundtrip = roundtrip.map(_.delivered(identified.id)).flatMap {
                 case r if r.eventIds.isEmpty =>
-                  push(ro, r.response(state))
+                  push(ro, r.responseFactory(state))
                   if (requestUpstreamFinished) completeStage() else tryPullCi()
                   None
                 case r =>

--- a/src/test/scala/com/github/krasserm/ases/EventSourcingSpec.scala
+++ b/src/test/scala/com/github/krasserm/ases/EventSourcingSpec.scala
@@ -38,8 +38,8 @@ object EventSourcingSpec {
   case class Response(state: Int)
 
   val requestHandler: RequestHandler[Int, Incremented, Request, Response] = {
-    case (_, GetState)     => (Seq(), Response)
-    case (s, Increment(d)) => (Seq(Incremented(d)), Response)
+    case (s, GetState)     => respond(Response(s))
+    case (_, Increment(d)) => emit(Seq(Incremented(d)), Response)
   }
 
   val eventHandler: EventHandler[Int, Incremented] =

--- a/src/test/scala/com/github/krasserm/ases/RequestRoutingSpec.scala
+++ b/src/test/scala/com/github/krasserm/ases/RequestRoutingSpec.scala
@@ -38,8 +38,8 @@ object RequestRoutingSpec {
   case class Response(aggregateId: String, state: Int)
 
   val requestHandler: RequestHandler[Int, Incremented, Request, Response] = {
-    case (_, GetState(aggregateId))     => (Seq(), Response(aggregateId, _))
-    case (s, Increment(aggregateId, d)) => (Seq(Incremented(aggregateId, d)), Response(aggregateId, _))
+    case (s, GetState(aggregateId))     => respond(Response(aggregateId, s))
+    case (_, Increment(aggregateId, d)) => emit(Seq(Incremented(aggregateId, d)), Response(aggregateId, _))
   }
 
   val eventHandler: EventHandler[Int, Incremented] =


### PR DESCRIPTION
- user-defined handler providers are evaluated with current state
- non-switching API implemented on top of switching API
- request handler result DSL: respond, emit
- closes #3