### PR TITLE
Custom Serializers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import de.heikoseeberger.sbtheader.license.Apache2_0
+import sbtprotobuf.ProtobufPlugin
 
 lazy val commonSettings = Seq(
   organization := "com.github.krasserm",
@@ -18,6 +19,11 @@ lazy val headerSettings = Seq(headers := Map(
   "scala" -> header,
   "java" -> header
 ))
+
+lazy val protocSettings: Seq[Setting[_]] = ProtobufPlugin.protobufSettings ++ Seq(
+  version in ProtobufPlugin.protobufConfig := Version.Protobuf,
+  ProtobufPlugin.runProtoc in ProtobufPlugin.protobufConfig := (args => com.github.os72.protocjar.Protoc.runProtoc("-v330" +: args.toArray))
+)
 
 lazy val dependencies = Seq(
   "com.typesafe.akka" %% "akka-persistence"         % Version.Akka ,
@@ -40,4 +46,5 @@ lazy val root = (project in file("."))
   .settings(commonSettings: _*)
   .settings(testSettings: _*)
   .settings(headerSettings: _*)
+  .settings(protocSettings: _*)
   .settings(libraryDependencies ++= dependencies)

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,5 @@
 object Version {
   val Akka = "2.5.2"
   val Kafka = "0.10.2.1"
+  val Protobuf = "3.3.0"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,5 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.6.0")
+
+addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.4.0")
+
+libraryDependencies += "com.github.os72" % "protoc-jar" % "3.3.0.1"

--- a/src/main/protobuf/EmittedFormat.proto
+++ b/src/main/protobuf/EmittedFormat.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "com.github.krasserm.ases.serializer";
+option optimize_for = SPEED;
+
+import "PayloadFormat.proto";
+
+message EmittedFormat {
+  PayloadFormat event = 1;
+  string emitterId = 2;
+  string emissionUuid = 3;
+}

--- a/src/main/protobuf/PayloadFormat.proto
+++ b/src/main/protobuf/PayloadFormat.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_package = "com.github.krasserm.ases.serializer";
+option optimize_for = SPEED;
+
+message PayloadFormat {
+  int32 serializerId = 1;
+  bytes payload = 2;
+  string payloadManifest = 3;
+  bool isStringManifest = 4;
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,8 @@
+akka.actor {
+  serializers {
+    ases-emitted = "com.github.krasserm.ases.serializer.EmittedSerializer"
+  }
+  serialization-bindings {
+    "com.github.krasserm.ases.Emitted" = ases-emitted
+  }
+}

--- a/src/main/scala/com/github/krasserm/ases/serializer/EmittedSerializer.scala
+++ b/src/main/scala/com/github/krasserm/ases/serializer/EmittedSerializer.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.krasserm.ases.serializer
+
+import java.io.NotSerializableException
+
+import akka.actor.ExtendedActorSystem
+import akka.serialization.Serializer
+import com.github.krasserm.ases.Emitted
+import com.github.krasserm.ases.serializer.EmittedFormatOuterClass.EmittedFormat
+
+class EmittedSerializer(system: ExtendedActorSystem) extends Serializer {
+
+  private val EmittedClass = classOf[Emitted[_]]
+  private val payloadSerializer = new PayloadSerializer(system)
+
+  override def identifier: Int = 17406883
+
+  override def includeManifest: Boolean = true
+
+  override def toBinary(o: AnyRef): Array[Byte] = o match {
+    case emitted: Emitted[_] =>
+      emittedFormat(emitted).toByteArray
+    case _ =>
+      throw new IllegalArgumentException(s"Invalid object of type '${o.getClass}' supplied to serializer [id = '$identifier']")
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = manifest match {
+    case Some(`EmittedClass`) =>
+      emitted(EmittedFormat.parseFrom(bytes))
+    case None =>
+      emitted(EmittedFormat.parseFrom(bytes))
+    case _ =>
+      throw new NotSerializableException(s"Unknown manifest '$manifest' supplied to serializer [id = '$identifier']")
+  }
+
+  private def emittedFormat(emitted: Emitted[Any]): EmittedFormat = {
+    EmittedFormat.newBuilder()
+      .setEvent(payloadSerializer.payloadFormatBuilder(emitted.event.asInstanceOf[AnyRef]))
+      .setEmitterId(emitted.emitterId)
+      .setEmissionUuid(emitted.emissionUuid)
+      .build()
+  }
+
+  private def emitted(format: EmittedFormat): Emitted[_] = {
+    Emitted(
+      payloadSerializer.payload(format.getEvent),
+      format.getEmitterId,
+      format.getEmissionUuid
+    )
+  }
+ }

--- a/src/main/scala/com/github/krasserm/ases/serializer/PayloadSerializer.scala
+++ b/src/main/scala/com/github/krasserm/ases/serializer/PayloadSerializer.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.krasserm.ases.serializer
+
+import akka.actor.ExtendedActorSystem
+import akka.serialization.{SerializationExtension, SerializerWithStringManifest}
+import com.github.krasserm.ases.serializer.PayloadFormatOuterClass.PayloadFormat
+import com.google.protobuf.ByteString
+
+import scala.util.Try
+
+class PayloadSerializer(system: ExtendedActorSystem) {
+
+  def payloadFormatBuilder(payload: AnyRef): PayloadFormat.Builder = {
+    val serializer = SerializationExtension(system).findSerializerFor(payload)
+    val builder = PayloadFormat.newBuilder()
+
+    if (serializer.includeManifest) {
+      val (isStringManifest, manifest) = serializer match {
+        case s: SerializerWithStringManifest => (true, s.manifest(payload))
+        case _ => (false, payload.getClass.getName)
+      }
+      builder.setIsStringManifest(isStringManifest)
+      builder.setPayloadManifest(manifest)
+    }
+    builder.setSerializerId(serializer.identifier)
+    builder.setPayload(ByteString.copyFrom(serializer.toBinary(payload)))
+  }
+
+  def payload(payloadFormat: PayloadFormat): AnyRef = {
+    val payload = if (payloadFormat.getIsStringManifest)
+      payloadFromStringManifest(payloadFormat)
+    else if (payloadFormat.getPayloadManifest.nonEmpty)
+      payloadFromClassManifest(payloadFormat)
+    else
+      payloadFromEmptyManifest(payloadFormat)
+
+    payload.get
+  }
+
+  private def payloadFromStringManifest(payloadFormat: PayloadFormat): Try[AnyRef] = {
+    SerializationExtension(system).deserialize(
+      payloadFormat.getPayload.toByteArray,
+      payloadFormat.getSerializerId,
+      payloadFormat.getPayloadManifest
+    )
+  }
+
+  private def payloadFromClassManifest(payloadFormat: PayloadFormat): Try[AnyRef]  = {
+    val manifestClass = system.dynamicAccess.getClassFor[AnyRef](payloadFormat.getPayloadManifest).get
+    SerializationExtension(system).deserialize(
+      payloadFormat.getPayload.toByteArray,
+      payloadFormat.getSerializerId,
+      Some(manifestClass)
+    )
+  }
+
+  private def payloadFromEmptyManifest(payloadFormat: PayloadFormat): Try[AnyRef]  = {
+    SerializationExtension(system).deserialize(
+      payloadFormat.getPayload.toByteArray,
+      payloadFormat.getSerializerId,
+      None
+    )
+  }
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,4 +1,18 @@
-akka.actor.warn-about-java-serializer-usage = off
+akka.actor {
+  warn-about-java-serializer-usage = on
+
+  serializers {
+    emitted-serializer-spec-string-manifest = "com.github.krasserm.ases.serializer.EmittedSerializerSpec$StringManifestEventSerializer"
+    emitted-serializer-spec-class-manifest = "com.github.krasserm.ases.serializer.EmittedSerializerSpec$ClassManifestEventSerializer"
+    emitted-serializer-spec-empty-manifest = "com.github.krasserm.ases.serializer.EmittedSerializerSpec$EmptyManifestEventSerializer"
+  }
+
+  serialization-bindings {
+    "com.github.krasserm.ases.serializer.EmittedSerializerSpec$StringManifestEvent" = emitted-serializer-spec-string-manifest
+    "com.github.krasserm.ases.serializer.EmittedSerializerSpec$ClassManifestEvent" = emitted-serializer-spec-class-manifest
+    "com.github.krasserm.ases.serializer.EmittedSerializerSpec$EmptyManifestEvent" = emitted-serializer-spec-empty-manifest
+  }
+}
 akka.log-dead-letters-during-shutdown = off
 akka.log-dead-letters = off
 akka.test.single-expect-default = 5s

--- a/src/test/scala/com/github/krasserm/ases/SpecWords.scala
+++ b/src/test/scala/com/github/krasserm/ases/SpecWords.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.krasserm.ases
+
+import org.scalatest.WordSpecLike
+
+trait SpecWords {
+  this: WordSpecLike =>
+
+  val is = afterWord("is")
+  val isA = afterWord("is a")
+  val contains = afterWord("contains")
+  val invokedWith = afterWord("invokedWith")
+}

--- a/src/test/scala/com/github/krasserm/ases/StopSystemAfterAll.scala
+++ b/src/test/scala/com/github/krasserm/ases/StopSystemAfterAll.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.krasserm.ases
+
+import akka.testkit.TestKit
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait StopSystemAfterAll extends BeforeAndAfterAll {
+  this: TestKit with Suite =>
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+}

--- a/src/test/scala/com/github/krasserm/ases/serializer/EmittedSerializerSpec.scala
+++ b/src/test/scala/com/github/krasserm/ases/serializer/EmittedSerializerSpec.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.krasserm.ases.serializer
+
+import java.io.NotSerializableException
+
+import akka.actor.ActorSystem
+import akka.serialization.{SerializationExtension, Serializer, SerializerWithStringManifest}
+import akka.testkit.TestKit
+import com.github.krasserm.ases.{Emitted, SpecWords, StopSystemAfterAll}
+import com.google.protobuf
+import org.scalatest.{MustMatchers, WordSpecLike}
+
+object EmittedSerializerSpec {
+
+  case class StringManifestEvent(id: String)
+
+  case class ClassManifestEvent(id: String)
+
+  case class EmptyManifestEvent(id: String)
+
+  case class PlainEvent(id: String)
+
+  class StringManifestEventSerializer extends SerializerWithStringManifest {
+    val Manifest = "v1.Event"
+
+    override def identifier: Int = 11111101
+
+    override def manifest(o: AnyRef): String = Manifest
+
+    override def toBinary(o: AnyRef): Array[Byte] = o match {
+      case e: StringManifestEvent => e.id.getBytes
+      case _ => throw new IllegalArgumentException(s"Object of type '${o.getClass}' not supported")
+    }
+
+    override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
+      case Manifest => StringManifestEvent(new String(bytes))
+      case _ => throw new IllegalArgumentException(s"Object for manifest '$manifest' not supported")
+    }
+  }
+
+  class ClassManifestEventSerializer extends Serializer {
+    val ClassManifest = classOf[ClassManifestEvent]
+
+    override def identifier: Int = 11111102
+
+    override def includeManifest: Boolean = true
+
+    override def toBinary(o: AnyRef): Array[Byte] = o match {
+      case e: ClassManifestEvent => e.id.getBytes
+      case _ => throw new IllegalArgumentException(s"Object of type '${o.getClass}' not supported")
+    }
+
+    override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = manifest match {
+      case Some(`ClassManifest`) => ClassManifestEvent(new String(bytes))
+      case None => throw new IllegalArgumentException(s"No class manifest provided")
+      case _ => throw new IllegalArgumentException(s"Object for manifest '$manifest' not supported")
+    }
+  }
+
+  class EmptyManifestEventSerializer extends Serializer {
+
+    override def identifier: Int = 11111103
+
+    override def includeManifest: Boolean = false
+
+    override def toBinary(o: AnyRef): Array[Byte] = o match {
+      case e: EmptyManifestEvent => e.id.getBytes
+      case _ => throw new IllegalArgumentException(s"Object of type '${o.getClass}' not supported")
+    }
+
+    override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef =
+      EmptyManifestEvent(new String(bytes))
+  }
+}
+
+class EmittedSerializerSpec extends TestKit(ActorSystem("test")) with WordSpecLike with MustMatchers with SpecWords with StopSystemAfterAll {
+
+  import EmittedSerializerSpec._
+
+  val serialization = SerializationExtension(system)
+  val emittedSerializer = serialization.serializerFor(classOf[Emitted[_]])
+
+  def emitted[A](event: A): Emitted[A] =
+    Emitted(event, "emitter-1")
+
+  def serialize[A](emitted: Emitted[A]): Array[Byte] =
+    emittedSerializer.toBinary(emitted)
+
+  def deserialize[A](bytes: Array[Byte]): Emitted[A] =
+    emittedSerializer.fromBinary(bytes, classOf[Emitted[_]]).asInstanceOf[Emitted[A]]
+
+  def emittedSerializations[A](event: A): Unit = {
+    "serialize and deserialize the Emitted event with the given payload" in {
+      val original = emitted(event)
+
+      val bytes = serialize(original)
+      val deserialized = deserialize(bytes)
+
+      deserialized mustBe original
+    }
+  }
+
+  "An EmittedSerializer" when {
+    "serializing an object" that is {
+      "an Emitted event" which {
+        "contains an event payload assigned to a serializer" which isA {
+          "SerializerWithStringManifest" must {
+            behave like emittedSerializations(StringManifestEvent("ev-1"))
+          }
+          "Serializer with class-manifest" must {
+            behave like emittedSerializations(ClassManifestEvent("ev-1"))
+          }
+          "Serializer with an empty manifest" must {
+            behave like emittedSerializations(EmptyManifestEvent("ev-1"))
+          }
+          "JavaSerializer" must {
+            behave like emittedSerializations(PlainEvent("ev-1"))
+          }
+        }
+      }
+      "an invalid object" must {
+        "throw an IllegalArgumentException" in {
+          intercept[IllegalArgumentException] {
+            emittedSerializer.toBinary("invalid-object")
+          }
+        }
+      }
+    }
+    "deserializing a byte-array" that contains {
+      "an invalid binary representation" must {
+        "throw a NotSerializableException" in {
+          intercept[protobuf.InvalidProtocolBufferException] {
+            emittedSerializer.fromBinary("invalid-binary-representation".getBytes, classOf[Emitted[_]])
+          }
+        }
+      }
+      "a valid binary representation" when invokedWith {
+        val original = emitted(StringManifestEvent("ev-1"))
+
+        "an empty manifest" must {
+          "deserialize the Emitted event" in {
+            val deserialized = emittedSerializer.fromBinary(serialize(original), manifest = None)
+
+            deserialized mustBe original
+          }
+        }
+        "an unsupported manifest" must {
+          "throw a NotSerializableException" in {
+            intercept[NotSerializableException] {
+              emittedSerializer.fromBinary(serialize(original), manifest = Some(classOf[String]))
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implement an Akka-Serializer for the type `Emitted` which uses Google-Protobuf as the data-format of serialized objects.
Arbitrary event payloads of `Emitted` can be serialized provided that an Akka-Serializer is configured for the type of the given payload.

Closes: #7